### PR TITLE
Disable requirement for ShouldProcess support on New-UnitySetupComponent.

### DIFF
--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -170,6 +170,7 @@ class UnityVersion : System.IComparable
 function New-UnitySetupComponent
 {
     [CmdletBinding()]
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Scope = 'Function')]
     param(
         [parameter(Mandatory=$true)]
         [UnitySetupComponent] $Components


### PR DESCRIPTION
This "fixes" a linter warning from PSScriptAnalyzer.