### PR TITLE
Suppress inappropraitely applied rule

### DIFF
--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -482,10 +482,6 @@ function Install-UnitySetupInstance {
                 'PassThru' = $true;
                 'Wait' = $true;
             }
-
-            if ($Verb) {
-                $startProcessArgs['Verb'] = $Verb
-            }
             
             Write-Verbose "$(Get-Date): Installing $installer to $destination."
             $process = Start-Process @startProcessArgs
@@ -1001,6 +997,7 @@ function ConvertTo-DateTime {
 function Get-UnityLicense
 {
     [CmdletBinding()]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "", Justification="Used to convert discovered plaintext serials into secure strings.")]
     param([SecureString]$Serial)
 
     $licenseFiles = Get-ChildItem "C:\ProgramData\Unity\Unity_*.ulf" -ErrorAction 'SilentlyContinue'


### PR DESCRIPTION
That rule is there because having plain text passwords is bad. As this is the format in which Unity stores the serial I believe I'm improving security by converting it to a `SecureString` for any further use.

Resolves #113 