### PR TITLE
flip from start-bits to webclient. remove unused param - resolves #119

### DIFF
--- a/UnitySetup/UnitySetup.psd1
+++ b/UnitySetup/UnitySetup.psd1
@@ -14,7 +14,7 @@
     RootModule        = 'UnitySetup'
 
     # Version number of this module.
-    ModuleVersion     = '4.1'
+    ModuleVersion     = '5.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -421,11 +421,7 @@ function Install-UnitySetupInstance {
         [string]$Destination,
 
         [parameter(Mandatory = $false)]
-        [string]$Cache = [io.Path]::Combine($env:USERPROFILE, ".unitysetup"),
-
-        [parameter(Mandatory = $false)]
-        [ValidateSet('Open', 'RunAs')]
-        [string]$Verb
+        [string]$Cache = [io.Path]::Combine($env:USERPROFILE, ".unitysetup")
     )
 
     process {
@@ -471,7 +467,7 @@ function Install-UnitySetupInstance {
                 }
             }
 
-            Start-BitsTransfer -Source $downloadSource -Destination $downloadDest
+            (New-Object System.Net.WebClient).DownloadFile($downloadSource, $downloadDest)
         }
        
         for ($i = 0; $i -lt $localInstallers.Length; $i++) {

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -465,9 +465,9 @@ function Install-UnitySetupInstance {
                 if (!(Test-Path $destDirectory -PathType Container)) {
                     New-Item "$destDirectory" -ItemType Directory | Out-Null
                 }
-            }
 
-            (New-Object System.Net.WebClient).DownloadFile($downloadSource, $downloadDest)
+                (New-Object System.Net.WebClient).DownloadFile($downloadSource, $downloadDest)
+            }
         }
        
         for ($i = 0; $i -lt $localInstallers.Length; $i++) {

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -466,7 +466,7 @@ function Install-UnitySetupInstance {
                     New-Item "$destDirectory" -ItemType Directory | Out-Null
                 }
 
-                (New-Object System.Net.WebClient).DownloadFile($downloadSource, $downloadDest)
+                (New-Object System.Net.WebClient).DownloadFile($downloadSource[$i], $downloadDest[$i])
             }
         }
        


### PR DESCRIPTION
start-bits doesn't work on VSTS build agents.  Webclient calls do. 