### PR TITLE
Mac Install Support

### DIFF
--- a/UnitySetup/UnitySetup.psd1
+++ b/UnitySetup/UnitySetup.psd1
@@ -76,8 +76,11 @@
 
     FunctionsToExport = @(
         'Find-UnitySetupInstaller',
+        'Select-UnitySetupInstaller',
+        'Test-UnitySetupInstance',
         'Get-UnityProjectInstance',
         'Get-UnitySetupInstance',
+        'Request-UnitySetupInstaller',
         'Install-UnitySetupInstance',
         'Select-UnitySetupInstance',
         'Uninstall-UnitySetupInstance',

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -598,7 +598,7 @@ function Request-UnitySetupInstaller {
                     }
 
                     # TODO: Display in Kbps on slow networks.
-                    Write-Progress -Activity "$("{0:N2}" -f $averageSpeed) Mbps`nDownloading $($_.DownloadUrl)" `
+                    Write-Progress -Activity "$("{0:N2}" -f $averageSpeed) Mbps | Downloading $installerFileName" `
                         -Status "$($receivedBytes | Get-FileSize) of $($totalBytes | Get-FileSize)" `
                         -SecondsRemaining $secondsRemaining `
                         -PercentComplete $progress

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -665,10 +665,11 @@ function Request-UnitySetupInstaller {
                 }
             }
 
-            $totalDownloads = $global:downloadData.Count
-
             # Showing progress of all file downloads
-            while ($global:downloadData.Count -gt 0) {
+            $totalDownloads = $global:downloadData.Count
+            do {
+                $installersDownloaded = 0
+
                 $global:downloadData.Keys | ForEach-Object {
                     $installerFileName = $_
                     $data = $global:downloadData[$installerFileName]
@@ -720,7 +721,7 @@ function Request-UnitySetupInstaller {
                         -PercentComplete $progress `
                         -Id $data.downloadIndex
                 }
-            }
+            } while ($installersDownloaded -lt $totalDownloads)
         }
         finally {
             # If the script is stopped, e.g. Ctrl+C, we want to cancel any remaining downloads

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -432,6 +432,22 @@ function Find-UnitySetupInstaller {
     } | Sort-Object -Property ComponentType
 }
 
+<#
+.Synopsis
+   Test if a Unity instance is installed.
+.DESCRIPTION
+   Returns the status of a Unity install by Version and/or Path to install.
+.PARAMETER Version
+   What version of Unity are you looking for?
+.PARAMETER BasePath
+   Under what base patterns is Unity customly installed at.
+.PARAMETER Path
+   Exact path you expect Unity to be installed at.
+.EXAMPLE
+   Test-UnitySetupInstance -Version 2017.3.0f3
+.EXAMPLE
+   Test-UnitySetupInstance -BasePath D:/UnityInstalls/Unity2018
+#>
 function Test-UnitySetupInstance {
     [CmdletBinding()]
     param(
@@ -533,6 +549,21 @@ function Format-BitsPerSecond {
     )
 }
 
+<#
+.Synopsis
+   Download specified Unity installers.
+.DESCRIPTION
+   Filters a list of `UnitySetupInstaller` down to a specific version and/or specific components.
+.PARAMETER Installers
+   List of installers that needs to be downloaded.
+.PARAMETER Cache
+   File path where installers will be downloaded to.
+.EXAMPLE
+   $installers = Find-UnitySetupInstaller -Version 2017.3.0f3
+   Request-UnitySetupInstaller -Installers $installers
+.EXAMPLE
+   Find-UnitySetupInstaller -Version 2017.3.0f3 | Request-UnitySetupInstaller
+#>
 function Request-UnitySetupInstaller {
     [CmdletBinding()]
     param(

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -676,6 +676,7 @@ function Request-UnitySetupInstaller {
 
                     # Finished downloading
                     if ($null -eq $data.webClient) {
+                        ++$installersDownloaded
                         return
                     }
                     if ($data.isDownloaded) {


### PR DESCRIPTION
- Restructures `Install-UnitySetupInstance` to better support the needs for mac package installs.
- Separates downloading packages from installing packages.
- Handles proper PowerShell piping for commands.
- Converts WebClient to be Async and gives a progress bar for status of download.
- Fixes caching issue with WebClient downloads.
- Enables filtering of installers and instances based off directory paths.

TODO: (non-blocking)
- Error handling (enhancements?)
- Support for upgrading previous installs.
- ~~Investigate Unity Hub (beta) on Mac to inspect how they're getting packages installed into other directories.~~ *This is resolved using sparsebundles*