### PR TITLE
Add support for alpha versions

### DIFF
--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -147,7 +147,7 @@ class UnityVersion : System.IComparable {
     UnityVersion([string] $version) {
         $parts = $version.Split('-')
 
-        $parts[0] -match "(\d+)\.(\d+)\.(\d+)([fpb])(\d+)" | Out-Null
+        $parts[0] -match "(\d+)\.(\d+)\.(\d+)([fpba])(\d+)" | Out-Null
         if ( $Matches.Count -ne 6 ) { throw "Invalid unity version: $version" }
         $this.Major = [int]($Matches[1]);
         $this.Minor = [int]($Matches[2]);
@@ -347,6 +347,7 @@ function Find-UnitySetupInstaller {
     $searchPages = @()
     switch ($Version.Release) {
         'f' { $searchPages += "https://unity3d.com/get-unity/download/archive" }
+        'a' { $searchPages += "https://unity3d.com/unity/alpha/$Version" }
         'b' { $searchPages += "https://unity3d.com/unity/beta/unity$Version" }
         'p' {
             $patchPage = "https://unity3d.com/unity/qa/patch-releases?version=$($Version.Major).$($Version.Minor)"


### PR DESCRIPTION
This PR shouldn't break any of existing features.

Example of version that is considered Invalid: `2019.1.0a10`
Example of download link: https://unity3d.com/unity/alpha/2019.1.0a10
Example of exception that this PR should fix:
```
Exception setting "Version": "Cannot convert value "2019.1.0a10" to type "UnityVersion". Error: "Invalid unity version: 2019.1.0a10""
At C:\Users\Artem\Documents\WindowsPowerShell\Modules\UnitySetup\4.0.97\UnitySetup.psm1:128 char:9
+         $this.Version = $fileVersion
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], SetValueInvocationException
    + FullyQualifiedErrorId : ExceptionWhenSetting
```
