### PR TITLE
add quotes around project path

### DIFF
--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -963,7 +963,7 @@ function Start-UnityEditor {
             }
 
             $projectPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($($p.Path))
-            $instanceArgs += , ("-projectPath", "$projectPath")
+            $instanceArgs += , ("-projectPath", "`"$projectPath`"")
             $setupInstances += , $setupInstance
         }
 

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -963,7 +963,7 @@ function Start-UnityEditor {
             }
 
             $projectPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($($p.Path))
-            $instanceArgs += , ("-projectPath", $projectPath)
+            $instanceArgs += , ("-projectPath", "$projectPath")
             $setupInstances += , $setupInstance
         }
 


### PR DESCRIPTION
Fixes #138 by adding quotes around project path within the argument string.

Example output:
```
VERBOSE: Performing the operation "Start-Process" on target "C:\Program
Files\Unity\Hub\Editor\2018.3.0f2\Editor\Unity.exe -projectPath "C:\Developer Projects\<ProjectRoot>\<UnityProject>\"".
```