### PR TITLE
Add AdditionalArguments flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Launch many projects at the same time:
 ```powershell
 Get-UnityProjectInstance -Recurse | Start-UnityEditor
 ```
+Invoke methods with arbitrary arguments:
+```powershell
+Start-UnityEditor -ExecuteMethod Build.Invoke -BatchMode -Quit -LogFile .\build.log -Wait -AdditionalArguments "-BuildArg1 -BuildArg2"
+```
 Find the installers for a particular version:
 ```powershell
 Find-UnitySetupInstaller -Version '2017.3.0f3' | Format-Table

--- a/UnitySetup/UnitySetup.psd1
+++ b/UnitySetup/UnitySetup.psd1
@@ -14,7 +14,7 @@
     RootModule        = 'UnitySetup'
 
     # Version number of this module.
-    ModuleVersion     = '5.0'
+    ModuleVersion     = '5.1'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -754,6 +754,8 @@ function Get-UnityProjectInstance {
    Force operation as though $PWD is not a unity project.
 .PARAMETER ExecuteMethod
    The script method for the Unity Editor to execute.
+.PARAMETER AdditionalArguments
+   Additiong arguments for Unity or your custom method
 .PARAMETER OutputPath
    The output path that the Unity Editor should use.
 .PARAMETER LogFile
@@ -824,6 +826,8 @@ function Start-UnityEditor {
         [switch]$IgnoreProjectContext,
         [parameter(Mandatory = $false)]
         [string]$ExecuteMethod,
+        [parameter(Mandatory = $false)]
+        [string]$AdditionalArguments,
         [parameter(Mandatory = $false)]
         [string[]]$ExportPackage,
         [parameter(Mandatory = $false)]
@@ -962,6 +966,7 @@ function Start-UnityEditor {
         if ( $TestResults ) { $sharedArgs += '-testResults', $TestResults }
         if ( $RunTests ) { $sharedArgs += '-runTests' }
         if ( $ForceFree) { $sharedArgs += '-force-free' }
+        if ( $AdditionalArguments) { $sharedArgs += $AdditionalArguments }
 
         $instanceArgs = @()
         foreach ( $p in $projectInstances ) {

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -755,7 +755,7 @@ function Get-UnityProjectInstance {
 .PARAMETER ExecuteMethod
    The script method for the Unity Editor to execute.
 .PARAMETER AdditionalArguments
-   Additiong arguments for Unity or your custom method
+   Additional arguments for Unity or your custom method
 .PARAMETER OutputPath
    The output path that the Unity Editor should use.
 .PARAMETER LogFile
@@ -797,7 +797,7 @@ function Get-UnityProjectInstance {
 .EXAMPLE
    Start-UnityEditor -Version 2017.3.0f3
 .EXAMPLE
-   Start-UnityEditor -ExecuteMethod Build.Invoke -BatchMode -Quit -LogFile .\build.log -Wait
+   Start-UnityEditor -ExecuteMethod Build.Invoke -BatchMode -Quit -LogFile .\build.log -Wait -AdditionalArguments "-BuildArg1 -BuildArg2"
 .EXAMPLE
    Get-UnityProjectInstance -Recurse | Start-UnityEditor -BatchMode -Quit
 .EXAMPLE


### PR DESCRIPTION
This flag allows you to provide additional arguments for unity command line. This is useful for cases where we do not support unity command line flags. It is also useful for providing arbitrary arguments alongside ExecuteMethod.

Resolves #145