### PR TITLE
Fix hang with Start-UnityEditor -Quit -Wait

### DIFF
--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -73,14 +73,14 @@ class UnitySetupInstance {
                 $this.Components = [UnitySetupComponent]::Windows
                 $playbackEnginePath = [io.path]::Combine("$Path", "Editor\Data\PlaybackEngines");
                 @{
-                    [UnitySetupComponent]::Documentation = , [io.path]::Combine("$Path", "Editor\Data\Documentation");
+                    [UnitySetupComponent]::Documentation  = , [io.path]::Combine("$Path", "Editor\Data\Documentation");
                     [UnitySetupComponent]::StandardAssets = , [io.path]::Combine("$Path", "Editor\Standard Assets");
                     [UnitySetupComponent]::Windows_IL2CPP = , [io.path]::Combine("$playbackEnginePath", "windowsstandalonesupport\Variations\win32_development_il2cpp");
-                    [UnitySetupComponent]::UWP = [io.path]::Combine("$playbackEnginePath", "MetroSupport\Templates\UWP_.NET_D3D"),
+                    [UnitySetupComponent]::UWP            = [io.path]::Combine("$playbackEnginePath", "MetroSupport\Templates\UWP_.NET_D3D"),
                     [io.path]::Combine("$playbackEnginePath", "MetroSupport\Templates\UWP_D3D");
-                    [UnitySetupComponent]::UWP_IL2CPP = , [io.path]::Combine("$playbackEnginePath", "MetroSupport\Templates\UWP_IL2CPP_D3D");
-                    [UnitySetupComponent]::Linux = , [io.path]::Combine("$playbackEnginePath", "LinuxStandaloneSupport");
-                    [UnitySetupComponent]::Mac = , [io.path]::Combine("$playbackEnginePath", "MacStandaloneSupport");
+                    [UnitySetupComponent]::UWP_IL2CPP     = , [io.path]::Combine("$playbackEnginePath", "MetroSupport\Templates\UWP_IL2CPP_D3D");
+                    [UnitySetupComponent]::Linux          = , [io.path]::Combine("$playbackEnginePath", "LinuxStandaloneSupport");
+                    [UnitySetupComponent]::Mac            = , [io.path]::Combine("$playbackEnginePath", "MacStandaloneSupport");
                 }
             }
             ([OperatingSystem]::Linux) {
@@ -92,10 +92,10 @@ class UnitySetupInstance {
                 $this.Components = [UnitySetupComponent]::Mac
                 $playbackEnginePath = [io.path]::Combine("$Path", "PlaybackEngines");
                 @{
-                    [UnitySetupComponent]::Documentation = , [io.path]::Combine("$Path", "Documentation");
+                    [UnitySetupComponent]::Documentation  = , [io.path]::Combine("$Path", "Documentation");
                     [UnitySetupComponent]::StandardAssets = , [io.path]::Combine("$Path", "Standard Assets");
-                    [UnitySetupComponent]::Windows = , [io.path]::Combine("$playbackEnginePath", "WindowsStandaloneSupport");
-                    [UnitySetupComponent]::Linux = , [io.path]::Combine("$playbackEnginePath", "LinuxStandaloneSupport");
+                    [UnitySetupComponent]::Windows        = , [io.path]::Combine("$playbackEnginePath", "WindowsStandaloneSupport");
+                    [UnitySetupComponent]::Linux          = , [io.path]::Combine("$playbackEnginePath", "LinuxStandaloneSupport");
                 }
             }
         }
@@ -301,18 +301,18 @@ function Find-UnitySetupInstaller {
     )
 
     $installerTemplates = @{
-        [UnitySetupComponent]::UWP = "$targetSupport/UnitySetup-UWP-.NET-Support-for-Editor-$Version.$installerExtension",
-         "$targetSupport/UnitySetup-Metro-Support-for-Editor-$Version.$installerExtension";
-        [UnitySetupComponent]::UWP_IL2CPP = , "$targetSupport/UnitySetup-UWP-IL2CPP-Support-for-Editor-$Version.$installerExtension";
-        [UnitySetupComponent]::Android = , "$targetSupport/UnitySetup-Android-Support-for-Editor-$Version.$installerExtension";
-        [UnitySetupComponent]::iOS = , "$targetSupport/UnitySetup-iOS-Support-for-Editor-$Version.$installerExtension";
-        [UnitySetupComponent]::AppleTV = , "$targetSupport/UnitySetup-AppleTV-Support-for-Editor-$Version.$installerExtension";
-        [UnitySetupComponent]::Facebook = , "$targetSupport/UnitySetup-Facebook-Games-Support-for-Editor-$Version.$installerExtension";
-        [UnitySetupComponent]::Linux = , "$targetSupport/UnitySetup-Linux-Support-for-Editor-$Version.$installerExtension";
-        [UnitySetupComponent]::Mac = "$targetSupport/UnitySetup-Mac-Support-for-Editor-$Version.$installerExtension",
+        [UnitySetupComponent]::UWP            = "$targetSupport/UnitySetup-UWP-.NET-Support-for-Editor-$Version.$installerExtension",
+        "$targetSupport/UnitySetup-Metro-Support-for-Editor-$Version.$installerExtension";
+        [UnitySetupComponent]::UWP_IL2CPP     = , "$targetSupport/UnitySetup-UWP-IL2CPP-Support-for-Editor-$Version.$installerExtension";
+        [UnitySetupComponent]::Android        = , "$targetSupport/UnitySetup-Android-Support-for-Editor-$Version.$installerExtension";
+        [UnitySetupComponent]::iOS            = , "$targetSupport/UnitySetup-iOS-Support-for-Editor-$Version.$installerExtension";
+        [UnitySetupComponent]::AppleTV        = , "$targetSupport/UnitySetup-AppleTV-Support-for-Editor-$Version.$installerExtension";
+        [UnitySetupComponent]::Facebook       = , "$targetSupport/UnitySetup-Facebook-Games-Support-for-Editor-$Version.$installerExtension";
+        [UnitySetupComponent]::Linux          = , "$targetSupport/UnitySetup-Linux-Support-for-Editor-$Version.$installerExtension";
+        [UnitySetupComponent]::Mac            = "$targetSupport/UnitySetup-Mac-Support-for-Editor-$Version.$installerExtension",
         "$targetSupport/UnitySetup-Mac-Mono-Support-for-Editor-$Version.$installerExtension";
-        [UnitySetupComponent]::Vuforia = , "$targetSupport/UnitySetup-Vuforia-AR-Support-for-Editor-$Version.$installerExtension";
-        [UnitySetupComponent]::WebGL = , "$targetSupport/UnitySetup-WebGL-Support-for-Editor-$Version.$installerExtension";
+        [UnitySetupComponent]::Vuforia        = , "$targetSupport/UnitySetup-Vuforia-AR-Support-for-Editor-$Version.$installerExtension";
+        [UnitySetupComponent]::WebGL          = , "$targetSupport/UnitySetup-WebGL-Support-for-Editor-$Version.$installerExtension";
         [UnitySetupComponent]::Windows_IL2CPP = , "$targetSupport/UnitySetup-Windows-IL2CPP-Support-for-Editor-$Version.$installerExtension";
     }
 
@@ -426,10 +426,10 @@ function Find-UnitySetupInstaller {
                     }
                     $result = New-Object UnitySetupInstaller -Property @{
                         'ComponentType' = $_;
-                        'Version' = $Version;
-                        'DownloadUrl' = $endpoint;
-                        'Length' = $installerLength;
-                        'LastModified' = $lastModified;
+                        'Version'       = $Version;
+                        'DownloadUrl'   = $endpoint;
+                        'Length'        = $installerLength;
+                        'LastModified'  = $lastModified;
                     }
 
                     break
@@ -532,13 +532,13 @@ function Select-UnitySetupInstaller {
 }
 
 filter Format-Bytes {
-	return "{0:N2} {1}" -f $(
-        if ($_ -lt 1kb)     { $_, 'Bytes' }
-        elseif ($_ -lt 1mb) { ($_/1kb), 'KB' }
-        elseif ($_ -lt 1gb) { ($_/1mb), 'MB' }
-        elseif ($_ -lt 1tb) { ($_/1gb), 'GB' }
-        elseif ($_ -lt 1pb) { ($_/1tb), 'TB' }
-        else                { ($_/1pb), 'PB' }
+    return "{0:N2} {1}" -f $(
+        if ($_ -lt 1kb) { $_, 'Bytes' }
+        elseif ($_ -lt 1mb) { ($_ / 1kb), 'KB' }
+        elseif ($_ -lt 1gb) { ($_ / 1mb), 'MB' }
+        elseif ($_ -lt 1tb) { ($_ / 1gb), 'GB' }
+        elseif ($_ -lt 1pb) { ($_ / 1tb), 'TB' }
+        else { ($_ / 1pb), 'PB' }
     )
 }
 
@@ -556,13 +556,13 @@ function Format-BitsPerSecond {
     }
     # Convert from bytes to bits
     $Bits = ($Bytes * 8) / $Seconds
-	return "{0:N2} {1}" -f $(
-        if ($Bits -lt 1kb)     { $Bits, 'Bps' }
-        elseif ($Bits -lt 1mb) { ($Bits/1kb), 'Kbps' }
-        elseif ($Bits -lt 1gb) { ($Bits/1mb), 'Mbps' }
-        elseif ($Bits -lt 1tb) { ($Bits/1gb), 'Gbps' }
-        elseif ($Bits -lt 1pb) { ($Bits/1tb), 'Tbps' }
-        else                   { ($Bits/1pb), 'Pbps' }
+    return "{0:N2} {1}" -f $(
+        if ($Bits -lt 1kb) { $Bits, 'Bps' }
+        elseif ($Bits -lt 1mb) { ($Bits / 1kb), 'Kbps' }
+        elseif ($Bits -lt 1gb) { ($Bits / 1mb), 'Mbps' }
+        elseif ($Bits -lt 1tb) { ($Bits / 1gb), 'Gbps' }
+        elseif ($Bits -lt 1pb) { ($Bits / 1tb), 'Tbps' }
+        else { ($Bits / 1pb), 'Pbps' }
     )
 }
 
@@ -630,7 +630,7 @@ function Request-UnitySetupInstaller {
 
                         $resource = New-Object UnitySetupResource -Property @{
                             'ComponentType' = $_.ComponentType
-                            'Path' = $destination
+                            'Path'          = $destination
                         }
                         $downloads += , $resource
                         return
@@ -647,15 +647,15 @@ function Request-UnitySetupInstaller {
                 ++$downloadIndex
                 $global:downloadData[$installerFileName] = New-Object PSObject -Property @{
                     installerFileName = $installerFileName
-                    startTime = Get-Date
-                    totalBytes = $_.Length
-                    receivedBytes = 0
-                    isDownloaded = $false
-                    destination = $destination
-                    lastModified = $_.LastModified
-                    componentType = $_.ComponentType
-                    webClient = $webClient
-                    downloadIndex = $downloadIndex
+                    startTime         = Get-Date
+                    totalBytes        = $_.Length
+                    receivedBytes     = 0
+                    isDownloaded      = $false
+                    destination       = $destination
+                    lastModified      = $_.LastModified
+                    componentType     = $_.ComponentType
+                    webClient         = $webClient
+                    downloadIndex     = $downloadIndex
                 }
 
                 # Register to events for showing progress of file download.
@@ -666,8 +666,7 @@ function Request-UnitySetupInstaller {
                     $global:downloadData[$event.MessageData].isDownloaded = $true
                 } | Out-Null
 
-                try
-                {
+                try {
                     Write-Verbose "Downloading $($_.DownloadUrl) to $destination"
                     $webClient.DownloadFileAsync($_.DownloadUrl, $destination)
                 }
@@ -712,7 +711,7 @@ function Request-UnitySetupInstaller {
             
                         $resource = New-Object UnitySetupResource -Property @{
                             'ComponentType' = $data.componentType
-                            'Path' = $data.destination
+                            'Path'          = $data.destination
                         }
                         $downloads += , $resource
                         return
@@ -781,10 +780,10 @@ function Install-UnitySetupPackage {
     switch ($currentOS) {
         ([OperatingSystem]::Windows) {
             $startProcessArgs = @{
-                'FilePath' = $Package.Path;
+                'FilePath'     = $Package.Path;
                 'ArgumentList' = @("/S", "/D=$Destination");
-                'PassThru' = $true;
-                'Wait' = $true;
+                'PassThru'     = $true;
+                'Wait'         = $true;
             }
         }
         ([OperatingSystem]::Linux) {
@@ -794,10 +793,10 @@ function Install-UnitySetupPackage {
             # Note that $Destination has to be a disk path.
             # sudo installer -package $Package.Path -target /
             $startProcessArgs = @{
-                'FilePath' = 'sudo';
+                'FilePath'     = 'sudo';
                 'ArgumentList' = @("installer", "-package", $Package.Path, "-target", $Destination);
-                'PassThru' = $true;
-                'Wait' = $true;
+                'PassThru'     = $true;
+                'Wait'         = $true;
             }
         }
     }
@@ -977,8 +976,7 @@ function Install-UnitySetupInstance {
             # Move the install from the sparse bundle disk to the install directory.
             if ($currentOS -eq [OperatingSystem]::Mac) {
                 # rsync does not recursively create the directory path.
-                if (-not (Test-Path $installPath -PathType Container))
-                {
+                if (-not (Test-Path $installPath -PathType Container)) {
                     Write-Verbose "Creating directory $installPath."
                     New-Item $installPath -ItemType Directory -ErrorAction Stop | Out-Null
                 }
@@ -1031,10 +1029,10 @@ function Uninstall-UnitySetupInstance {
             }
 
             $startProcessArgs = @{
-                'FilePath' = $uninstaller;
-                'PassThru' = $true;
-                'Wait' = $true;
-                'ErrorAction' = 'Stop';
+                'FilePath'     = $uninstaller;
+                'PassThru'     = $true;
+                'Wait'         = $true;
+                'ErrorAction'  = 'Stop';
                 'ArgumentList' = @("/S");
             }
 
@@ -1178,10 +1176,10 @@ function Get-UnityProjectInstance {
     )
 
     $args = @{
-        'Path' = $BasePath;
-        'Filter' = 'ProjectSettings';
+        'Path'        = $BasePath;
+        'Filter'      = 'ProjectSettings';
         'ErrorAction' = 'Ignore';
-        'Directory' = $true;
+        'Directory'   = $true;
     }
 
     if ( $Recurse ) {
@@ -1582,7 +1580,7 @@ function Get-IsUnityError {
 function ConvertTo-DateTime {
     param([string] $Text)
 
-    if( -not $text -or $text.Length -eq 0 ) { [DateTime]::MaxValue }
+    if ( -not $text -or $text.Length -eq 0 ) { [DateTime]::MaxValue }
     else { [DateTime]$Text }
 }
 
@@ -1594,10 +1592,9 @@ function ConvertTo-DateTime {
 .EXAMPLE
    Get-UnityLicense
 #>
-function Get-UnityLicense
-{
+function Get-UnityLicense {
     [CmdletBinding()]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "", Justification="Used to convert discovered plaintext serials into secure strings.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "", Justification = "Used to convert discovered plaintext serials into secure strings.")]
     param([SecureString]$Serial)
 
     $licenseFiles = Get-ChildItem "C:\ProgramData\Unity\Unity_*.ulf" -ErrorAction 'SilentlyContinue'
@@ -1608,18 +1605,18 @@ function Get-UnityLicense
 
         # The first four bytes look like a count so skip that to pull out the serial string
         $licenseSerial = [String]::new($devBytes[4..($devBytes.Length - 1)])
-        if( $Serial -and [System.Net.NetworkCredential]::new($null, $Serial).Password -ne $licenseSerial ) { continue; }
+        if ( $Serial -and [System.Net.NetworkCredential]::new($null, $Serial).Password -ne $licenseSerial ) { continue; }
         
         $license = $doc.root.License
         [PSCustomObject]@{
             'LicenseVersion' = $license.LicenseVersion.Value
-            'Serial' = ConvertTo-SecureString $licenseSerial -AsPlainText -Force
-            'UnityVersion' = [UnityVersion]$license.ClientProvidedVersion.Value
-            'DisplaySerial' = $license.SerialMasked.Value
+            'Serial'         = ConvertTo-SecureString $licenseSerial -AsPlainText -Force
+            'UnityVersion'   = [UnityVersion]$license.ClientProvidedVersion.Value
+            'DisplaySerial'  = $license.SerialMasked.Value
             'ActivationDate' = ConvertTo-DateTime $license.InitialActivationDate.Value
-            'StartDate' = ConvertTo-DateTime $license.StartDate.Value
-            'StopDate' = ConvertTo-DateTime $license.StopDate.Value
-            'UpdateDate' = ConvertTo-DateTime $license.UpdateDate.Value
+            'StartDate'      = ConvertTo-DateTime $license.StartDate.Value
+            'StopDate'       = ConvertTo-DateTime $license.StopDate.Value
+            'UpdateDate'     = ConvertTo-DateTime $license.UpdateDate.Value
         }
     }
 }


### PR DESCRIPTION
The main change is in the first commit - swapping out Start-Process for System.Diagnostics.Process.Start. For some reason Start-Process -Wait results in extra long waits after unity.exe has exited.

Current theory is that it's waiting for the handles to redirected output to close or a child process of unity.exe. Either way avoiding Start-Process -Wait has made the issue irreproducible.

The second commit includes auto-formatting that VS Code applied.