### PR TITLE
Fixes 2019.1 Unity Instance Searching

### DIFF
--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -1101,8 +1101,7 @@ function Get-UnitySetupInstance {
         }
     }
 
-    $searchPaths = Get-ChildItem $BasePath | Get-ChildItem | ForEach-Object { $_.Directory.FullName }
-    $searchPaths = $searchPaths | Select-Object -uniq
+    $searchPaths = Get-ChildItem $BasePath -Directory
     $setupInstances = [UnitySetupInstance[]]@()
 
     foreach ( $path in $searchPaths ) {

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -55,10 +55,10 @@ class UnitySetupInstance {
             $modules = (Get-Content "$path\modules.json" -Raw) | ConvertFrom-Json
 
             foreach ( $module in $modules ) {
-                $module.DownloadUrl -match "(\d+)\.(\d+)\.(\d+)([fpb])(\d+)" | Out-Null
+                $match = $module.DownloadUrl -match "(\d+)\.(\d+)\.(\d+)([fpb])(\d+)" | Out-Null
 
-                if ( $Matches -ne $null ) {
-                    $this.Version = [UnityVersion]$Matches[0]
+                if ( $null -ne $match ) {
+                    $this.Version = [UnityVersion]$match
                     break
                 }
             }

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -49,11 +49,11 @@ class UnitySetupInstance {
     [string]$Path
 
     UnitySetupInstance([string]$path) {
+        $version = $null
         $currentOS = Get-OperatingSystem
 
         # First we'll attempt to search for the version using the ivy.xml definitions for legacy editor compatibility.
         $ivy = Get-ChildItem -Path $path -Filter ivy.xml -Recurse -ErrorAction SilentlyContinue -Force | Select-Object -First 1
-        $version = $null
 
         if ( Test-Path $ivy.FullName ){
             [xml]$xmlDoc = Get-Content $ivy.FullName
@@ -65,7 +65,8 @@ class UnitySetupInstance {
 
             foreach ( $module in $modules ) {
                 $module.DownloadUrl -match "(\d+)\.(\d+)\.(\d+)([fpb])(\d+)" | Out-Null
-                if( $Matches[0] -ne $null ){
+
+                if ( $Matches[0] -ne $null ) {
                     $version = $Matches[0]
                     break
                 }

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -55,7 +55,7 @@ class UnitySetupInstance {
             $modules = (Get-Content "$path\modules.json" -Raw) | ConvertFrom-Json
 
             foreach ( $module in $modules ) {
-                $match = $module.DownloadUrl -match "(\d+)\.(\d+)\.(\d+)([fpb])(\d+)" | Out-Null
+                $match = $module.DownloadUrl -match "(\d+)\.(\d+)\.(\d+)([fpab])(\d+)" | Out-Null
 
                 if ( $null -ne $match ) {
                     $this.Version = [UnityVersion]$match
@@ -73,7 +73,7 @@ class UnitySetupInstance {
             }
         }
 
-        if ( -not $this.Version ) {
+        if ( $this.Version -ne $null ) {
             throw "Failed to find a valid version identifier for installation at $path!";
         }
 

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -64,8 +64,8 @@ class UnitySetupInstance {
                     [UnitySetupComponent]::Documentation  = , [io.path]::Combine("$Path", "Editor\Data\Documentation");
                     [UnitySetupComponent]::StandardAssets = , [io.path]::Combine("$Path", "Editor\Standard Assets");
                     [UnitySetupComponent]::Windows_IL2CPP = , [io.path]::Combine("$playbackEnginePath", "windowsstandalonesupport\Variations\win32_development_il2cpp");
-                    [UnitySetupComponent]::UWP            = [io.path]::Combine("$playbackEnginePath", "MetroSupport\Templates\UWP_.NET_D3D"),
-                    [io.path]::Combine("$playbackEnginePath", "MetroSupport\Templates\UWP_D3D");
+                    [UnitySetupComponent]::UWP            =   [io.path]::Combine("$playbackEnginePath", "MetroSupport\Templates\UWP_.NET_D3D"),
+                                                              [io.path]::Combine("$playbackEnginePath", "MetroSupport\Templates\UWP_D3D");
                     [UnitySetupComponent]::UWP_IL2CPP     = , [io.path]::Combine("$playbackEnginePath", "MetroSupport\Templates\UWP_IL2CPP_D3D");
                     [UnitySetupComponent]::Linux          = , [io.path]::Combine("$playbackEnginePath", "LinuxStandaloneSupport");
                     [UnitySetupComponent]::Mac            = , [io.path]::Combine("$playbackEnginePath", "MacStandaloneSupport");
@@ -90,12 +90,12 @@ class UnitySetupInstance {
         }
 
         # Common playback engines:
-        $componentTests[[UnitySetupComponent]::Android] = , [io.path]::Combine("$playbackEnginePath", "AndroidPlayer");
-        $componentTests[[UnitySetupComponent]::iOS] = , [io.path]::Combine("$playbackEnginePath", "iOSSupport");
-        $componentTests[[UnitySetupComponent]::AppleTV] = , [io.path]::Combine("$playbackEnginePath", "AppleTVSupport");
+        $componentTests[[UnitySetupComponent]::Android]  = , [io.path]::Combine("$playbackEnginePath", "AndroidPlayer");
+        $componentTests[[UnitySetupComponent]::iOS]      = , [io.path]::Combine("$playbackEnginePath", "iOSSupport");
+        $componentTests[[UnitySetupComponent]::AppleTV]  = , [io.path]::Combine("$playbackEnginePath", "AppleTVSupport");
         $componentTests[[UnitySetupComponent]::Facebook] = , [io.path]::Combine("$playbackEnginePath", "Facebook");
-        $componentTests[[UnitySetupComponent]::Vuforia] = , [io.path]::Combine("$playbackEnginePath", "VuforiaSupport");
-        $componentTests[[UnitySetupComponent]::WebGL] = , [io.path]::Combine("$playbackEnginePath", "WebGLSupport");
+        $componentTests[[UnitySetupComponent]::Vuforia]  = , [io.path]::Combine("$playbackEnginePath", "VuforiaSupport");
+        $componentTests[[UnitySetupComponent]::WebGL]    = , [io.path]::Combine("$playbackEnginePath", "WebGLSupport");
 
         $componentTests.Keys | ForEach-Object {
             foreach ( $test in $componentTests[$_] ) {
@@ -306,8 +306,8 @@ function Find-UnitySetupInstaller {
         [UnitySetupComponent]::AppleTV        = , "$targetSupport/UnitySetup-AppleTV-Support-for-Editor-$Version.$installerExtension";
         [UnitySetupComponent]::Facebook       = , "$targetSupport/UnitySetup-Facebook-Games-Support-for-Editor-$Version.$installerExtension";
         [UnitySetupComponent]::Linux          = , "$targetSupport/UnitySetup-Linux-Support-for-Editor-$Version.$installerExtension";
-        [UnitySetupComponent]::Mac            = "$targetSupport/UnitySetup-Mac-Support-for-Editor-$Version.$installerExtension",
-        "$targetSupport/UnitySetup-Mac-Mono-Support-for-Editor-$Version.$installerExtension";
+        [UnitySetupComponent]::Mac            =   "$targetSupport/UnitySetup-Mac-Support-for-Editor-$Version.$installerExtension",
+                                                  "$targetSupport/UnitySetup-Mac-Mono-Support-for-Editor-$Version.$installerExtension";
         [UnitySetupComponent]::Mac_IL2CPP     = , "$targetSupport/UnitySetup-Mac-IL2CPP-Support-for-Editor-$Version.$installerExtension";
         [UnitySetupComponent]::Vuforia        = , "$targetSupport/UnitySetup-Vuforia-AR-Support-for-Editor-$Version.$installerExtension";
         [UnitySetupComponent]::WebGL          = , "$targetSupport/UnitySetup-WebGL-Support-for-Editor-$Version.$installerExtension";
@@ -1075,8 +1075,8 @@ function Get-UnitySetupInstance {
         }
     }
 
-    Get-ChildItem $BasePath -Directory | Where-Object { 
-        Test-Path (Join-Path $_.FullName 'Editor\Unity.exe') -PathType Leaf 
+    Get-ChildItem $BasePath -Directory | Where-Object {
+        Test-Path (Join-Path $_.FullName 'Editor\Unity.exe') -PathType Leaf
     } | ForEach-Object {
         $path = $_.FullName
         try {
@@ -1126,7 +1126,7 @@ function Get-UnitySetupInstanceVersion {
             return [UnityVersion]$Matches[0]
         }
     }
-    
+
     if ( Test-Path "$path\Editor" -PathType Container ) {
         # We'll attempt to search for the version using the ivy.xml definitions for legacy editor compatibility.
 
@@ -1136,12 +1136,12 @@ function Get-UnitySetupInstanceVersion {
             if ( $null -eq $ivy ) { continue; }
 
             Write-Verbose "`tLooking for version in $($ivy.FullName)"
-            
+
             [xml]$xmlDoc = Get-Content $ivy.FullName
 
             [string]$version = $xmlDoc.'ivy-module'.info.unityVersion
             if ( -not $version ) { continue; }
-            
+
             Write-Verbose "`tFound version!"
             return [UnityVersion]$version
         }

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -298,8 +298,8 @@ function Find-UnitySetupInstaller {
     )
 
     $installerTemplates = @{
-        [UnitySetupComponent]::UWP            = "$targetSupport/UnitySetup-UWP-.NET-Support-for-Editor-$Version.$installerExtension",
-        "$targetSupport/UnitySetup-Metro-Support-for-Editor-$Version.$installerExtension";
+        [UnitySetupComponent]::UWP            =   "$targetSupport/UnitySetup-UWP-.NET-Support-for-Editor-$Version.$installerExtension",
+                                                  "$targetSupport/UnitySetup-Metro-Support-for-Editor-$Version.$installerExtension";
         [UnitySetupComponent]::UWP_IL2CPP     = , "$targetSupport/UnitySetup-UWP-IL2CPP-Support-for-Editor-$Version.$installerExtension";
         [UnitySetupComponent]::Android        = , "$targetSupport/UnitySetup-Android-Support-for-Editor-$Version.$installerExtension";
         [UnitySetupComponent]::iOS            = , "$targetSupport/UnitySetup-iOS-Support-for-Editor-$Version.$installerExtension";

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -50,6 +50,7 @@ class UnitySetupInstance {
 
     UnitySetupInstance([string]$path) {
         $currentOS = Get-OperatingSystem
+        $foundVersion = $false
 
         if ( Test-Path "$path\modules.json" ) {
             $modules = (Get-Content "$path\modules.json" -Raw) | ConvertFrom-Json
@@ -59,6 +60,7 @@ class UnitySetupInstance {
 
                 if ( $null -ne $match ) {
                     $this.Version = [UnityVersion]$match
+                    $foundVersion = $true
                     break
                 }
             }
@@ -70,10 +72,11 @@ class UnitySetupInstance {
             if ( $null -ne $ivy ) {
                 [xml]$xmlDoc = Get-Content $ivy.FullName
                 $this.Version = [UnityVersion]$xmlDoc.'ivy-module'.info.unityVersion
+                $foundVersion = $true
             }
         }
 
-        if ( $this.Version -ne $null ) {
+        if ( $foundVersion -eq $false ) {
             throw "Failed to find a valid version identifier for installation at $path!";
         }
 
@@ -1105,6 +1108,7 @@ function Get-UnitySetupInstance {
     $setupInstances = [UnitySetupInstance[]]@()
 
     foreach ( $path in $searchPaths ) {
+        if( $path -like '*Unity Hub*' ) { continue }
         $setupInstances += , [UnitySetupInstance]::new($path)
     }
 

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -64,8 +64,8 @@ class UnitySetupInstance {
                     [UnitySetupComponent]::Documentation  = , [io.path]::Combine("$Path", "Editor\Data\Documentation");
                     [UnitySetupComponent]::StandardAssets = , [io.path]::Combine("$Path", "Editor\Standard Assets");
                     [UnitySetupComponent]::Windows_IL2CPP = , [io.path]::Combine("$playbackEnginePath", "windowsstandalonesupport\Variations\win32_development_il2cpp");
-                    [UnitySetupComponent]::UWP            =   [io.path]::Combine("$playbackEnginePath", "MetroSupport\Templates\UWP_.NET_D3D"),
-                                                              [io.path]::Combine("$playbackEnginePath", "MetroSupport\Templates\UWP_D3D");
+                    [UnitySetupComponent]::UWP            = [io.path]::Combine("$playbackEnginePath", "MetroSupport\Templates\UWP_.NET_D3D"),
+                    [io.path]::Combine("$playbackEnginePath", "MetroSupport\Templates\UWP_D3D");
                     [UnitySetupComponent]::UWP_IL2CPP     = , [io.path]::Combine("$playbackEnginePath", "MetroSupport\Templates\UWP_IL2CPP_D3D");
                     [UnitySetupComponent]::Linux          = , [io.path]::Combine("$playbackEnginePath", "LinuxStandaloneSupport");
                     [UnitySetupComponent]::Mac            = , [io.path]::Combine("$playbackEnginePath", "MacStandaloneSupport");
@@ -90,12 +90,12 @@ class UnitySetupInstance {
         }
 
         # Common playback engines:
-        $componentTests[[UnitySetupComponent]::Android]  = , [io.path]::Combine("$playbackEnginePath", "AndroidPlayer");
-        $componentTests[[UnitySetupComponent]::iOS]      = , [io.path]::Combine("$playbackEnginePath", "iOSSupport");
-        $componentTests[[UnitySetupComponent]::AppleTV]  = , [io.path]::Combine("$playbackEnginePath", "AppleTVSupport");
+        $componentTests[[UnitySetupComponent]::Android] = , [io.path]::Combine("$playbackEnginePath", "AndroidPlayer");
+        $componentTests[[UnitySetupComponent]::iOS] = , [io.path]::Combine("$playbackEnginePath", "iOSSupport");
+        $componentTests[[UnitySetupComponent]::AppleTV] = , [io.path]::Combine("$playbackEnginePath", "AppleTVSupport");
         $componentTests[[UnitySetupComponent]::Facebook] = , [io.path]::Combine("$playbackEnginePath", "Facebook");
-        $componentTests[[UnitySetupComponent]::Vuforia]  = , [io.path]::Combine("$playbackEnginePath", "VuforiaSupport");
-        $componentTests[[UnitySetupComponent]::WebGL]    = , [io.path]::Combine("$playbackEnginePath", "WebGLSupport");
+        $componentTests[[UnitySetupComponent]::Vuforia] = , [io.path]::Combine("$playbackEnginePath", "VuforiaSupport");
+        $componentTests[[UnitySetupComponent]::WebGL] = , [io.path]::Combine("$playbackEnginePath", "WebGLSupport");
 
         $componentTests.Keys | ForEach-Object {
             foreach ( $test in $componentTests[$_] ) {
@@ -298,16 +298,16 @@ function Find-UnitySetupInstaller {
     )
 
     $installerTemplates = @{
-        [UnitySetupComponent]::UWP            =   "$targetSupport/UnitySetup-UWP-.NET-Support-for-Editor-$Version.$installerExtension",
-                                                  "$targetSupport/UnitySetup-Metro-Support-for-Editor-$Version.$installerExtension";
+        [UnitySetupComponent]::UWP            = "$targetSupport/UnitySetup-UWP-.NET-Support-for-Editor-$Version.$installerExtension",
+        "$targetSupport/UnitySetup-Metro-Support-for-Editor-$Version.$installerExtension";
         [UnitySetupComponent]::UWP_IL2CPP     = , "$targetSupport/UnitySetup-UWP-IL2CPP-Support-for-Editor-$Version.$installerExtension";
         [UnitySetupComponent]::Android        = , "$targetSupport/UnitySetup-Android-Support-for-Editor-$Version.$installerExtension";
         [UnitySetupComponent]::iOS            = , "$targetSupport/UnitySetup-iOS-Support-for-Editor-$Version.$installerExtension";
         [UnitySetupComponent]::AppleTV        = , "$targetSupport/UnitySetup-AppleTV-Support-for-Editor-$Version.$installerExtension";
         [UnitySetupComponent]::Facebook       = , "$targetSupport/UnitySetup-Facebook-Games-Support-for-Editor-$Version.$installerExtension";
         [UnitySetupComponent]::Linux          = , "$targetSupport/UnitySetup-Linux-Support-for-Editor-$Version.$installerExtension";
-        [UnitySetupComponent]::Mac            =   "$targetSupport/UnitySetup-Mac-Support-for-Editor-$Version.$installerExtension",
-                                                  "$targetSupport/UnitySetup-Mac-Mono-Support-for-Editor-$Version.$installerExtension";
+        [UnitySetupComponent]::Mac            = "$targetSupport/UnitySetup-Mac-Support-for-Editor-$Version.$installerExtension",
+        "$targetSupport/UnitySetup-Mac-Mono-Support-for-Editor-$Version.$installerExtension";
         [UnitySetupComponent]::Mac_IL2CPP     = , "$targetSupport/UnitySetup-Mac-IL2CPP-Support-for-Editor-$Version.$installerExtension";
         [UnitySetupComponent]::Vuforia        = , "$targetSupport/UnitySetup-Vuforia-AR-Support-for-Editor-$Version.$installerExtension";
         [UnitySetupComponent]::WebGL          = , "$targetSupport/UnitySetup-WebGL-Support-for-Editor-$Version.$installerExtension";
@@ -1075,7 +1075,7 @@ function Get-UnitySetupInstance {
         }
     }
 
-    $results = Get-ChildItem $BasePath -Directory | Where-Object { 
+    Get-ChildItem $BasePath -Directory | Where-Object { 
         Test-Path (Join-Path $_.FullName 'Editor\Unity.exe') -PathType Leaf 
     } | ForEach-Object {
         $path = $_.FullName
@@ -1087,8 +1087,6 @@ function Get-UnitySetupInstance {
             Write-Warning "$_"
         }
     }
-
-    $results
 }
 
 <#

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -52,15 +52,7 @@ class UnitySetupInstance {
         $version = $null
         $currentOS = Get-OperatingSystem
 
-        # First we'll attempt to search for the version using the ivy.xml definitions for legacy editor compatibility.
-        $ivy = Get-ChildItem -Path $path -Filter ivy.xml -Recurse -ErrorAction SilentlyContinue -Force | Select-Object -First 1
-
-        if ( Test-Path $ivy.FullName ) {
-            [xml]$xmlDoc = Get-Content $ivy.FullName
-            $version = [UnityVersion]$xmlDoc.'ivy-module'.info.unityVersion
-        }
-        else {
-            # No ivy files found, so search the new modules.json for the version
+        if ( Test-Path "$path\modules.json" ) {
             $modules = (Get-Content "$path\modules.json" -Raw) | ConvertFrom-Json
 
             foreach ( $module in $modules ) {
@@ -70,6 +62,15 @@ class UnitySetupInstance {
                     $version = [UnityVersion]$Matches[0]
                     break
                 }
+            }
+        }
+        else {
+            # We'll attempt to search for the version using the ivy.xml definitions for legacy editor compatibility.
+            $ivy = Get-ChildItem -Path $path -Filter ivy.xml -Recurse -ErrorAction SilentlyContinue -Force | Select-Object -First 1
+
+            if ( Test-Path $ivy.FullName ) {
+                [xml]$xmlDoc = Get-Content $ivy.FullName
+                $version = [UnityVersion]$xmlDoc.'ivy-module'.info.unityVersion
             }
         }
 

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -52,15 +52,20 @@ class UnitySetupInstance {
         $currentOS = Get-OperatingSystem
         $foundVersion = $false
 
+        Write-Verbose "Attempting to get Unity Setup Instance at $path"
+
         if ( Test-Path "$path\modules.json" ) {
+
             $modules = (Get-Content "$path\modules.json" -Raw) | ConvertFrom-Json
 
             foreach ( $module in $modules ) {
-                $match = $module.DownloadUrl -match "(\d+)\.(\d+)\.(\d+)([fpab])(\d+)" | Out-Null
+                Write-Verbose "Found module $($module.id)"
+                Write-Verbose "Download Url $($module.DownloadUrl)"
 
-                if ( $null -ne $match ) {
-                    $this.Version = [UnityVersion]$match
+                if ( $module.DownloadUrl -match "(\d+)\.(\d+)\.(\d+)([fpab])(\d+)" ) {
+                    $this.Version = [UnityVersion]$Matches[0]
                     $foundVersion = $true
+                    Write-Verbose "Found $($this.Version)"
                     break
                 }
             }
@@ -1108,8 +1113,9 @@ function Get-UnitySetupInstance {
     $setupInstances = [UnitySetupInstance[]]@()
 
     foreach ( $path in $searchPaths ) {
-        if( $path -like '*Unity Hub*' ) { continue }
-        $setupInstances += , [UnitySetupInstance]::new($path)
+        if( $path -match "(\d+)\.(\d+)\.(\d+)([fpab])(\d+)") {
+            $setupInstances += , [UnitySetupInstance]::new($path)
+        }
     }
 
     return $setupInstances

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -1103,24 +1103,15 @@ function Get-UnitySetupInstance {
         }
     }
 
-    foreach ( $folder in $BasePath ) {
+    $searchPaths = Get-ChildItem $BasePath | Get-ChildItem | ForEach-Object { $_.Directory.FullName }
+    $searchPaths = $searchPaths | select -uniq
+    $setupInstances = [UnitySetupInstance[]]@()
 
-        if ( Test-Path "$folder\modules.json" ) {
-            $path = $folder
-        }
-        else {
-            $ivy = Get-ChildItem -Path $folder -Filter ivy.xml -Recurse -ErrorAction SilentlyContinue -Force | Select-Object -First 1
-
-            if ( Test-Path $ivy.FullName ) {
-                $path = $ivy.FullName
-            }
-        }
-
-        Get-ChildItem  $path -Recurse -ErrorAction Ignore |
-            ForEach-Object {
-            [UnitySetupInstance]::new((Join-Path $_.Directory "..\..\..\..\..\" | Convert-Path))
-        }
+    foreach ( $path in $searchPaths ) {
+        $setupInstances += , [UnitySetupInstance]::new($path)
     }
+
+    return $setupInstances
 }
 
 <#

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -1092,7 +1092,6 @@ function Get-UnitySetupInstance {
             if (-not $BasePath) {
                 $BasePath = @('C:\Program Files*\Unity*', 'C:\Program Files\Unity\Hub\Editor\*')
             }
-            $ivyPath = 'Editor\Data\UnityExtensions\Unity\Networking\ivy.xml'
         }
         ([OperatingSystem]::Linux) {
             throw "Get-UnitySetupInstance has not been implemented on the Linux platform. Contributions welcomed!";
@@ -1101,12 +1100,21 @@ function Get-UnitySetupInstance {
             if (-not $BasePath) {
                 $BasePath = @('/Applications/Unity*', '/Applications/Unity/Hub/Editor/*')
             }
-            $ivyPath = 'Unity.app/Contents/UnityExtensions/Unity/Networking/ivy.xml'
         }
     }
 
     foreach ( $folder in $BasePath ) {
-        $path = [io.path]::Combine("$folder", $ivyPath);
+
+        if ( Test-Path "$folder\modules.json" ) {
+            $path = $folder
+        }
+        else {
+            $ivy = Get-ChildItem -Path $folder -Filter ivy.xml -Recurse -ErrorAction SilentlyContinue -Force | Select-Object -First 1
+
+            if ( Test-Path $ivy.FullName ) {
+                $path = $ivy.FullName
+            }
+        }
 
         Get-ChildItem  $path -Recurse -ErrorAction Ignore |
             ForEach-Object {

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -73,7 +73,7 @@ class UnitySetupInstance {
             }
         }
 
-        if ( $version -eq $null ) {
+        if ( -not $this.Version ) {
             throw "Failed to find a valid version identifier for installation at $path!";
         }
 

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -55,7 +55,7 @@ class UnitySetupInstance {
         # First we'll attempt to search for the version using the ivy.xml definitions for legacy editor compatibility.
         $ivy = Get-ChildItem -Path $path -Filter ivy.xml -Recurse -ErrorAction SilentlyContinue -Force | Select-Object -First 1
 
-        if ( Test-Path $ivy.FullName ){
+        if ( Test-Path $ivy.FullName ) {
             [xml]$xmlDoc = Get-Content $ivy.FullName
             $version =  $xmlDoc.'ivy-module'.info.unityVersion
         }

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -57,7 +57,7 @@ class UnitySetupInstance {
 
         if ( Test-Path $ivy.FullName ) {
             [xml]$xmlDoc = Get-Content $ivy.FullName
-            $version =  $xmlDoc.'ivy-module'.info.unityVersion
+            $version = [UnityVersion]$xmlDoc.'ivy-module'.info.unityVersion
         }
         else {
             # No ivy files found, so search the new modules.json for the version
@@ -66,8 +66,8 @@ class UnitySetupInstance {
             foreach ( $module in $modules ) {
                 $module.DownloadUrl -match "(\d+)\.(\d+)\.(\d+)([fpb])(\d+)" | Out-Null
 
-                if ( $Matches[0] -ne $null ) {
-                    $version = $Matches[0]
+                if ( $Matches -ne $null ) {
+                    $version = [UnityVersion]$Matches[0]
                     break
                 }
             }


### PR DESCRIPTION
 Updated the `UnitySetupInstance` to search for the `modules.json` then falls back to recursively looking for `ivy.xml`

# Fixes:
- #168 