### PR TITLE
Gracefully handle UWP/UWP_IL2CPP components for Unity 2019.x

### DIFF
--- a/UnitySetup/DSCResources/xUnitySetupInstance/xUnitySetupInstance.psm1
+++ b/UnitySetup/DSCResources/xUnitySetupInstance/xUnitySetupInstance.psm1
@@ -23,7 +23,7 @@ function Get-TargetResource {
     $setupInstances = Get-UnitySetupInstance | Where-Object { $splitVersions -contains $_.Version }
     $result = @{
         "Versions" = $setupInstances | Select-Object -ExpandProperty Version | Sort-Object -Unique
-        "Ensure"   = if ($setupInstances.Count -gt 0) { 'Present'} else { 'Absent' }
+        "Ensure"   = if ($setupInstances.Count -gt 0) { 'Present' } else { 'Absent' }
     }
 
     Write-Verbose "Found versions: $($result['Versions'])"
@@ -81,7 +81,7 @@ function Set-TargetResource {
             foreach ($version in $splitVersions) {
                 $findArgs = @{ 
                     'Version'    = $version
-                    'Components' = ConvertTo-UnitySetupComponent $Components 
+                    'Components' = ConvertTo-UnitySetupComponent $Components -Version $version
                 }
 
                 $installArgs = @{ 'Cache' = "$env:TEMP\.unitysetup" }
@@ -158,9 +158,9 @@ function Test-TargetResource {
     $result = $true
     switch ( $Ensure ) {
         'Present' {
-            $setupComponents = ConvertTo-UnitySetupComponent $Components
             foreach ($version in $splitVersions) {
                 Write-Verbose "Starting test for $version"
+                $setupComponents = ConvertTo-UnitySetupComponent $Components -Version $version
                 $setupInstances = Get-UnitySetupInstance | Select-UnitySetupInstance -Version $version
                 Write-Verbose "Found $($setupInstances.Count) instance(s) of $version"
 

--- a/UnitySetup/UnitySetup.psd1
+++ b/UnitySetup/UnitySetup.psd1
@@ -14,7 +14,7 @@
     RootModule        = 'UnitySetup'
 
     # Version number of this module.
-    ModuleVersion     = '5.2'
+    ModuleVersion     = '5.3'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
This change will interpret any UnitySetupComponent combination of UWP,UWP_IL2CPP for any Unity 2019.x to mean UWP_IL2CPP. 

Resolves #186 