### PR TITLE
More robust Path testing in Select-UnitySetupInstance

### DIFF
--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -1296,11 +1296,17 @@ function Select-UnitySetupInstance {
         [UnitySetupInstance[]] $Instances
     )
 
+    begin {
+        if ( $Path ) {
+            $pathInfo = Resolve-Path $Path -ErrorAction Ignore
+        }
+    }
+
     process {
-        if ( $PSBoundParameters.ContainsKey('Path') ) {
-            $Path = $Path.TrimEnd([io.path]::DirectorySeparatorChar)
+        if ( $pathInfo ) {
             $Instances = $Instances | Where-Object {
-                $Path -eq (Get-Item $_.Path).FullName.TrimEnd([io.path]::DirectorySeparatorChar)
+                $instancePathInfo = Resolve-Path $_.Path -ErrorAction Ignore
+                return $pathInfo.Path -eq $instancePathInfo.Path
             }
         }
 


### PR DESCRIPTION
This allows the paths to be different cases and use different folder separators. It also safely handles null being passed.

This change fixes Test-UnitySetupInstance, which would previously report 'false' if a Path wasn't specified.