### PR TITLE
UnityProjectInstance fixed for older Unity versions

### DIFF
--- a/UnitySetup/UnitySetup.psd1
+++ b/UnitySetup/UnitySetup.psd1
@@ -14,7 +14,7 @@
     RootModule        = 'UnitySetup'
 
     # Version number of this module.
-    ModuleVersion     = '5.3'
+    ModuleVersion     = '5.4'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -125,8 +125,18 @@ class UnityProjectInstance {
         $projectSettingsFile = [io.path]::Combine($path, "ProjectSettings\ProjectSettings.asset")
         if (!(Test-Path $projectSettingsFile)) { throw "Project is missing ProjectSettings.asset" }
 
-        $prodName = ((Get-Content $projectSettingsFile -Raw | ConvertFrom-Yaml)['playerSettings'])['productName']
-        if (!$prodName) { throw "ProjectSettings is missing productName" }
+        try { 
+            $prodName = ((Get-Content $projectSettingsFile -Raw | ConvertFrom-Yaml)['playerSettings'])['productName']
+            if (!$prodName) { throw "ProjectSettings is missing productName" }
+        }
+        catch {
+            Write-Warning -Message "An Exception was caught!"
+            Write-Warning -Message "Exception Type: $($_.Exception.GetType().FullName)"
+            Write-Warning -Message "Exception Message: $($_.Exception.Message)"
+        }
+        finally{
+            $prodName = ""
+        }
 
         $this.Path = $path
         $this.Version = $fileVersion

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -130,9 +130,11 @@ class UnityProjectInstance {
             if (!$prodName) { throw "ProjectSettings is missing productName" }
         }
         catch {
-            Write-Warning -Message "An Exception was caught!"
-            Write-Warning -Message "Exception Type: $($_.Exception.GetType().FullName)"
-            Write-Warning -Message "Exception Message: $($_.Exception.Message)"
+            Write-Warning -Message "Could not read $projectSettingsFile, in the Unity project try setting Editor Settings > Asset Serialiazation Mode to 'Force Text'.
+            An Exception was caught!
+            Exception Type: $($_.Exception.GetType().FullName)
+            Exception Message: $($_.Exception.Message)"
+            
             $prodName = $null
         }
 

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -133,9 +133,7 @@ class UnityProjectInstance {
             Write-Warning -Message "An Exception was caught!"
             Write-Warning -Message "Exception Type: $($_.Exception.GetType().FullName)"
             Write-Warning -Message "Exception Message: $($_.Exception.Message)"
-        }
-        finally{
-            $prodName = ""
+            $prodName = $null
         }
 
         $this.Path = $path

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -130,10 +130,11 @@ class UnityProjectInstance {
             if (!$prodName) { throw "ProjectSettings is missing productName" }
         }
         catch {
-            Write-Warning -Message "Could not read $projectSettingsFile, in the Unity project try setting Editor Settings > Asset Serialiazation Mode to 'Force Text'.
-            An Exception was caught!
-            Exception Type: $($_.Exception.GetType().FullName)
-            Exception Message: $($_.Exception.Message)"
+            $msg = "Could not read $projectSettingsFile, in the Unity project try setting Editor Settings > Asset Serialiazation Mode to 'Force Text'."
+            $msg += "`nAn Exception was caught!"
+            $msg += "`nException Type: $($_.Exception.GetType().FullName)"
+            $msg += "`nException Message: $($_.Exception.Message)"
+            Write-Warning -Message $msg
             
             $prodName = $null
         }


### PR DESCRIPTION
- Fixed terminating exception when making a UnityProjectInstance from older versions of Unity

Versions such as 5.6.0f3 do not have projectsettings.asset files that can be read in the same way as newer versions of Unity.
