### PR TITLE
Fix issue with missing space in AdditionalArguments

### DIFF
--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -1788,7 +1788,7 @@ function Start-UnityEditor {
             }
         }
 
-        $sharedArgs = @()
+        [string[]]$sharedArgs = @()
         if ( $ReturnLicense ) {
             if ( -not $PSBoundParameters.ContainsKey('BatchMode') ) { $BatchMode = $true }
             if ( -not $PSBoundParameters.ContainsKey('Quit') ) { $Quit = $true }
@@ -1823,7 +1823,7 @@ function Start-UnityEditor {
         if ( $ForceFree) { $sharedArgs += '-force-free' }
         if ( $AdditionalArguments) { $sharedArgs += $AdditionalArguments }
 
-        $instanceArgs = @()
+        [string[][]]$instanceArgs = @()
         foreach ( $p in $projectInstances ) {
 
             if ( $Latest ) {
@@ -1864,7 +1864,7 @@ function Start-UnityEditor {
             }
 
             # clone the shared args list
-            $unityArgs = $sharedArgs | ForEach-Object { $_ }
+            [string[]]$unityArgs = $sharedArgs | ForEach-Object { $_ }
             if ( $instanceArgs[$i] ) { $unityArgs += $instanceArgs[$i] }
 
             $actionString = "$editor $unityArgs"


### PR DESCRIPTION
Ran into this issue below (observe the missing space between "ArgValue" and "-projectPath"):

```
sue -Project C:\Some\Unity\Project\ -AdditionalArguments "-ArgName ArgValue" -WhatIf
What if: Performing the operation "System.Diagnostics.Process.Start()" on target "C:\Program Files\Unity\Hub\Editor\2018.4.14f1\Editor\Unity.exe -ArgName ArgValue-projectPath "C:\Some\Unity\Project\"".
```
This was happening to do type inference not resulting in the desired outcomes when building up the arguments. Namely `$unityArgs` was being converted to a string upon construction rather than on assignment to `process.StartInfo.Arguments`. New explicit types resolves this issue.