### PR TITLE
Wrap each path individually in quotes to fix exports

### DIFF
--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -1810,7 +1810,7 @@ function Start-UnityEditor {
         if ( $BuildTarget ) { $sharedArgs += "-buildTarget", $BuildTarget }
         if ( $BatchMode ) { $sharedArgs += "-batchmode" }
         if ( $Quit ) { $sharedArgs += "-quit" }
-        if ( $ExportPackage ) { $sharedArgs += "-exportPackage", "`"$ExportPackage`"" }
+        if ( $ExportPackage ) { $sharedArgs += "-exportPackage", ($ExportPackage | ForEach-Object { "`"$_`"" }) }
         if ( $ImportPackage ) { $sharedArgs += "-importPackage", "`"$ImportPackage`"" }
         if ( $Credential ) { $sharedArgs += '-username', $Credential.UserName }
         if ( $EditorTestsCategory ) { $sharedArgs += '-editorTestsCategories', ($EditorTestsCategory -join ',') }


### PR DESCRIPTION
When running `Start-UnityEditor -Project "C:\some\unity\project" -ExportPackage "Assets/Some/Path", "Assets/Some/OtherPath", "SomePackage.unitypackage" -BatchMode -Quit` no package would be exported and Unity would output no errors.  After reverting to UnitySetup 5.3 I was successful. Reviewing the logs I noticed that the current implementation of quoting for `ExportPackage` was wrapping all paths in the array into one string.

This change fixes this argument to wrap each path individually before passing it on. This fixes exporting package from Unity.