### PR TITLE
Allow current set of test platforms

### DIFF
--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -1715,7 +1715,7 @@ function Start-UnityEditor {
         [parameter(Mandatory = $false)]
         [switch]$RunEditorTests,
         [parameter(Mandatory = $false)]
-        [ValidateSet('EditMode', 'PlayMode')]
+        [ValidateSet('EditMode', 'PlayMode', 'StandaloneWindows', 'StandaloneWindows64', 'StandaloneLinux64', 'StandaloneOSX', 'iOS', 'Android', 'PS4', 'XboxOne')]
         [string]$TestPlatform,
         [parameter(Mandatory = $false)]
         [string]$TestResults,


### PR DESCRIPTION
As per Unity Documentation: https://docs.unity3d.com/Packages/com.unity.test-framework@1.1/manual/reference-command-line.html

The wording on the documentation is a bit bad, however it allows to pass the test platform directly, switching automatically between EditMode und PlayMode and setting the BuildTarget directly. This is intended behaviour and exists since the integration of the Unity Testrunner, thus is downward compatible.