### PR TITLE
Add unity accelerator parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ Start-UnityEditor -Project .\MyUnityProject
 Start-UnityEditor -Project .\MyUnityProject -Latest
 Start-UnityEditor -Project .\MyUnityProject -Version '2017.3.0f3'
 ```
+
+Using the [Unity Accelerator](https://docs.unity3d.com/2019.3/Documentation/Manual/UnityAccelerator.html):
+```powershell
+Start-UnityEditor -Project .\MyUnityProject -CacheServerEndpoint 192.168.0.23 
+Start-UnityEditor -Project .\MyUnityProject -CacheServerEndpoint 192.168.0.23:2523 -CacheServerNamespacePrefix "dev"
+Start-UnityEditor -Project .\MyUnityProject -CacheServerEndpoint 192.168.0.23 -CacheServerNamespacePrefix "dev" -CacheServerDisableDownload
+Start-UnityEditor -Project .\MyUnityProject -CacheServerEndpoint 192.168.0.23 -CacheServerDisableUpload
+```
 Launch many projects at the same time:
 ```powershell
 Get-UnityProjectInstance -Recurse | Start-UnityEditor

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -1761,7 +1761,15 @@ function Start-UnityEditor {
         [parameter(Mandatory = $false)]
         [switch]$Wait,
         [parameter(Mandatory = $false)]
-        [switch]$PassThru
+        [switch]$PassThru,
+        [parameter(Mandatory = $false)]
+        [string]$CacheServerEndpoint,
+        [parameter(Mandatory = $false)]
+        [string]$CacheServerNamespacePrefix,
+        [parameter(Mandatory = $false)]
+        [switch]$CacheServerDisableDownload,
+        [parameter(Mandatory = $false)]
+        [switch]$CacheServerDisableUpload
     )
     process {
         switch -wildcard ( $PSCmdlet.ParameterSetName ) {
@@ -1855,6 +1863,14 @@ function Start-UnityEditor {
         if ( $RunTests ) { $sharedArgs += '-runTests' }
         if ( $ForceFree) { $sharedArgs += '-force-free' }
         if ( $AdditionalArguments) { $sharedArgs += $AdditionalArguments }
+        if ( $CacheServerEndpoint) {
+            $sharedArgs += "-cacheServerEndpoint", $CacheServerEndpoint  
+            $sharedArgs += "-adb2"
+            $sharedArgs += "-enableCacheServer"           
+            if ( $CacheServerNamespacePrefix) { $sharedArgs += "-cacheServerNamespacePrefix", $CacheServerNamespacePrefix}
+            $sharedArgs += "-cacheServerEnableDownload", $(If ($CacheServerDisableDownload) {"false"} Else {"true"})
+            $sharedArgs += "-cacheServerEnableUpload", $(If ($CacheServerDisableUpload) {"false"} Else {"true"})
+        }
 
         [string[][]]$instanceArgs = @()
         foreach ( $p in $projectInstances ) {

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -1678,6 +1678,14 @@ function Test-UnityProjectInstanceMetaFileIntegrity {
    Should the Unity Editor quit after it's done?
 .PARAMETER Wait
    Should the command wait for the Unity Editor to exit?
+.PARAMETER CacheServerEndpoint
+    If included, the editor will attempt to use a Unity Accelerator hosted in the provided IP. The endpoint should be in the format of [IP]:[Port]. If the default Accelerator port is used, at the time of writing this, the port should be ommited.
+.PARAMETER CacheServerNamespacePrefix
+    Set the namespace prefix. Used to group data together on the cache server. 
+.PARAMETER CacheServerDisableDownload
+    Disable downloading from the cache server. If ommited, the default value is true (download enabled)
+.PARAMETER CacheServerDisableUpload
+    Disable uploading to the cache server. If ommited, the default value is true (upload enabled)
 .EXAMPLE
    Start-UnityEditor
 .EXAMPLE


### PR DESCRIPTION
The unity cmd tools allow configure the [Unity Accelerator](https://docs.unity3d.com/2019.3/Documentation/Manual/UnityAccelerator.html) as specified [here](https://forum.unity.com/threads/usage-in-batchmode.819543/)

I'm just exposing those parameters and passing them down to Unity's cmd. 

There are 2 flags, `CacheServerDisableUpload` and `CacheServerDisableDownload` that can be specified if we want to **disable** specific behaviours. So the default would be **true**, to reduce clutter.