### PR TITLE
Catch json parse error, generalize to hashtable to bypass key overlap issue.

### DIFF
--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -1245,16 +1245,20 @@ function Get-UnitySetupInstanceVersion {
 
     # Try to look in the modules.json file for installer paths that contain version info
     if ( Test-Path "$path\modules.json" -PathType Leaf ) {
+        try {
+            Write-Verbose "Searching $path\modules.json for module versions"
+            $table = (Get-Content "$path\modules.json" -Raw) | ConvertFrom-Json -AsHashtable
 
-        Write-Verbose "Searching $path\modules.json for module versions"
-        $modules = (Get-Content "$path\modules.json" -Raw) | ConvertFrom-Json
+            foreach ( $url in $table.downloadUrl ) {
+                Write-Debug "`tTesting DownloadUrl $url"
+                if ( $url -notmatch "(\d+)\.(\d+)\.(\d+)([fpab])(\d+)" ) { continue; }
 
-        foreach ( $module in $modules ) {
-            Write-Verbose "`tTesting DownloadUrl $($module.DownloadUrl)"
-            if ( $module.DownloadUrl -notmatch "(\d+)\.(\d+)\.(\d+)([fpab])(\d+)" ) { continue; }
-
-            Write-Verbose "`tFound version!"
-            return [UnityVersion]$Matches[0]
+                Write-Verbose "`tFound version!"
+                return [UnityVersion]$Matches[0]
+            }
+        }
+        catch {
+            Write-Verbose "Error parsing $path\modules.json:`n`t$_"
         }
     }
 


### PR DESCRIPTION
Unity hub is writing 'preSelected' and 'preselected' to the manifest so I'm not parsing all the json into a hash table and looking at all download urls instead of requiring an understanding of the module shape in the json.

Also catching any future json parse errors, logging them to verbose, and not skipping the rest of the searches which may still work.

Note this appears to be a UnityHub issue rather than being tied to a particular unity version.

Resolves #237 