### PR TITLE
Fix pipeline issues where System token should be used for the PAT if valid

### DIFF
--- a/UnitySetup/UnitySetup.psd1
+++ b/UnitySetup/UnitySetup.psd1
@@ -55,7 +55,7 @@
     # Modules that must be imported into the global environment prior to importing this module
     RequiredModules   = @(
         @{ModuleName = "powershell-yaml"; ModuleVersion = "0.3"; Guid = "6a75a662-7f53-425a-9777-ee61284407da" },
-        @{ModuleName = "Az.Accounts"; ModuleVersion = "2.15.1"; Guid = "17a2feff-488b-47f9-8729-e2cec094624c" }
+        @{ModuleName = "Az.Accounts"; ModuleVersion = "1.8.0"; Guid = "17a2feff-488b-47f9-8729-e2cec094624c" }
     )
 
     # Assemblies that must be loaded prior to importing this module

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -2,6 +2,16 @@
 # Licensed under the MIT License.
 Import-Module powershell-yaml -MinimumVersion '0.3' -ErrorAction Stop
 
+$azAccountsVersion = Get-ModuleVersion -ModuleName "Az.Accounts"
+if ($azAccountsVersion) {
+    if ($azAccountsVersion -lt [version]"1.8" -or $azAccountsVersion -gt [version]"3.9.9999") {
+        if ($azAccountsVersion -ge [version]"4.0") {
+            Write-Error "Az.Accounts version 4.0 includes a breaking change and is not compatible."
+            exit 1
+        }
+    }
+}
+
 [Flags()]
 enum UnitySetupComponent {
     Windows = (1 -shl 0)
@@ -2236,10 +2246,6 @@ Would you like to continue? (Default: $($createPAT))"
 }
 
 function Confirm-PAT($Org, $Project, $FeedID, $RawPAT) {
-    if ($NoValidation) {
-        Write-Verbose "Skipping PAT validation because of -NoValidation flag"
-        return $true
-    }
     $user = 'any'
     $pass = $RawPAT
     $pair = "$($user):$($pass)"
@@ -2461,6 +2467,17 @@ function Update-PackageAuthConfig {
                 exit 1
             }
 
+            if($env:TF_BUILD) {
+                if(Confirm-PAT "$($OrgName)" "$($ProjectName)" "$($FeedName)" $env:SYSTEM_ACCESSTOKEN) {
+                    if($Verbose){Write-Host "System access token found"}
+                    $ScopedPAT = $env:SYSTEM_ACCESSTOKEN
+                    $AuthState = "Applied from system PAT"
+                } else {
+                    Write-Error "System access token found, but it was invalid for this org"
+                    $AuthState = "PAT is invalid"
+                }
+            }
+
             if (![string]::IsNullOrEmpty($ScopedPAT)) {
                 $convertedScopedPAT = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes(":" + $ScopedPAT.trim()))
 
@@ -2645,8 +2662,6 @@ function Import-UnityProjectManifest {
    A path to a project manifest, or a path to a root directory under which Unity project manifests can be found.
 .PARAMETER AutoClean
    Automatically remove PATs that can't be validated
-.PARAMETER NoValidation
-   Skip validation of PATs
 .PARAMETER ManualPAT
    Do not use Azure APIs to automatically create the PAT, user will manually enter it
 .PARAMETER SearchDepth
@@ -2661,8 +2676,6 @@ function Import-UnityProjectManifest {
    Update-UnityPackageManagerConfig -ProjectManifestPath '/User/myusername/MyUnityProjectRoot/manifest.json'
 .EXAMPLE
    Update-UnityPackageManagerConfig -AutoClean True
-.EXAMPLE
-   Update-UnityPackageManagerConfig -NoValidation True -ManualPAT True
 .EXAMPLE
    Update-UnityPackageManagerConfig -ProjectManifestPath '/User/myusername/MyUnityProjectRoot' -SearchDepth 7 -VerifyOnly True
 #>


### PR DESCRIPTION
I've been testing the new Cmdlet and discovered that we have scenarios where the agent machine is not authorized to generate a PAT via HTTP request, and there was some fallback code where we check if the SYSTEM_ACCESSTOKEN can be used as a valid pat and use that token in the .toml.

This pull request adds a conditional back in to check if this is the case for TF_BUILD environments.

Other minor changes:
- Min version of Az.Accounts should be 1.8+
- Add max version of Az.Accounts of 4.0 in anticipation of breaking changes  (assertion in the .psm1 on load)
- Cleaned up the NoValidation flag which is no longer passed through