### PR TITLE
Fix missing helper in Az.Accounts check

### DIFF
--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -2,6 +2,20 @@
 # Licensed under the MIT License.
 Import-Module powershell-yaml -MinimumVersion '0.3' -ErrorAction Stop
 
+function Get-ModuleVersion {
+    param (
+        [string]$ModuleName
+    )
+    $modules = Get-Module -Name $ModuleName -ListAvailable
+    if ($modules) {
+        $highestVersion = $modules | Sort-Object Version -Descending | Select-Object -First 1
+        return [version]$highestVersion.Version
+    }
+    else {
+        return $null
+    }
+}
+
 $azAccountsVersion = Get-ModuleVersion -ModuleName "Az.Accounts"
 if ($azAccountsVersion) {
     if ($azAccountsVersion -lt [version]"1.8" -or $azAccountsVersion -gt [version]"3.9.9999") {


### PR DESCRIPTION
It looks like I got bitten by a change I made after testing in-pipeline internally.   I had made all of the accesstoken updates in the psm1 file, but hadn't copied over the Az.Accounts check yet - and when I did so I neglected to copy the helper used in the version check.

Good that we didn't promote 166 to main!