### PR TITLE
Fixes for param validation, forwarding, and exit behavior

### DIFF
--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -2788,7 +2788,7 @@ function Update-UnityPackageManagerConfig {
         }
 
         Write-Verbose "Summary"
-        Format-Table -AutoSize -InputObject $upmConfigs
+        Write-Output $upmConfigs
     }
 
     if ($VerifyOnly) {


### PR DESCRIPTION
* Fixes for `AzureSubscription` to support use of `guid`
* Converted `PATLifetime` and `SearchDepth` to `uint` to enforce valid range
* Force `ProjectManifestPath` or `SearchPath` or both to be provided via parameter set name groupings.
* Only allow `SearchDepth` if `SearchPath` is provided.
* Validate `ProjectManifestPath` is a valid file in a `ValidateScript` attribute.
* Do not use 'exit' but thrown an exception instead - exit works ok from scripts, but not well from cmdlets.
* Fix bug where `ProjectManifestPath` was used as the search path if `SearchPath` was provided. `SearchPath `value was previously unused...
* Move Az module validation into function that requires it so other usage of UnitySetup is not blocked by it.