### PR TITLE
Add VisionOS component support

### DIFF
--- a/Tests/UnitTests/Find-UnitySetupInstaller.Tests.ps1
+++ b/Tests/UnitTests/Find-UnitySetupInstaller.Tests.ps1
@@ -1,19 +1,3 @@
-# BeforeEach {
-#     Import-Module "$PSScriptRoot\..\..\UnitySetup\UnitySetup.psd1" -Force
-
-#     Mock -CommandName 'Import-UnityProjectManifest' -MockWith { @() } -ModuleName UnitySetup
-#     Mock -CommandName 'Import-TOMLFile' -MockWith { @() } -ModuleName UnitySetup
-#     Mock -CommandName 'Update-PackageAuthConfig' -MockWith { @() } -ModuleName UnitySetup
-#     Mock -CommandName 'Export-UPMConfig' -MockWith { @() } -ModuleName UnitySetup
-#     Mock -CommandName 'Invoke-WebRequest' -MockWith {
-#         return [pscustomobject]@{
-#             StatusCode = 200
-#             Content    = '{"patToken": {"token": "mockedPATToken"}}'
-#         }
-#     } -ModuleName UnitySetup
-#     Mock -CommandName 'Confirm-PAT' -MockWith { $true } -ModuleName UnitySetup
-# }
-
 Describe 'Find-UnitySetupInstaller' {
 
     BeforeEach {

--- a/Tests/UnitTests/Find-UnitySetupInstaller.Tests.ps1
+++ b/Tests/UnitTests/Find-UnitySetupInstaller.Tests.ps1
@@ -1,0 +1,64 @@
+# BeforeEach {
+#     Import-Module "$PSScriptRoot\..\..\UnitySetup\UnitySetup.psd1" -Force
+
+#     Mock -CommandName 'Import-UnityProjectManifest' -MockWith { @() } -ModuleName UnitySetup
+#     Mock -CommandName 'Import-TOMLFile' -MockWith { @() } -ModuleName UnitySetup
+#     Mock -CommandName 'Update-PackageAuthConfig' -MockWith { @() } -ModuleName UnitySetup
+#     Mock -CommandName 'Export-UPMConfig' -MockWith { @() } -ModuleName UnitySetup
+#     Mock -CommandName 'Invoke-WebRequest' -MockWith {
+#         return [pscustomobject]@{
+#             StatusCode = 200
+#             Content    = '{"patToken": {"token": "mockedPATToken"}}'
+#         }
+#     } -ModuleName UnitySetup
+#     Mock -CommandName 'Confirm-PAT' -MockWith { $true } -ModuleName UnitySetup
+# }
+
+Describe 'Find-UnitySetupInstaller' {
+
+    BeforeEach {
+        Import-Module "$PSScriptRoot\..\..\UnitySetup\UnitySetup.psd1" -Force
+    }
+
+    Context 'Input Validation' {
+        It 'throws on invalidly formatted version' {
+            { Find-UnitySetupInstaller -Version "" } | Should -Throw "Cannot process argument transformation*"
+        }
+    }
+
+    Context 'Function Execution' {
+        It 'throws on non-existent version' {
+            { Find-UnitySetupInstaller -Version "1.2.3f1" } | Should -Throw "Could not find archives for Unity version*"
+        }
+
+        It 'finds an existing version' {
+            # https://unity.com/releases/editor/whats-new/2022.3.15 lists 13 for Windows, but we don't support Mac_Server
+            Find-UnitySetupInstaller -Version "2022.3.15f1" -ExplicitOS Windows | Should -HaveCount 12
+        }
+
+        # TODO: Support Mac ARM as a platform
+        # It 'does not find VisionOS before supported (Mac)' {
+        #     Find-UnitySetupInstaller -Version "2022.3.15f1" -Components VisionOS -ExplicitOS Mac | Should -HaveCount 0
+        # }
+
+        # It 'does find VisionOS once supported (Mac)' {
+        #     Find-UnitySetupInstaller -Version "2022.3.18f1" -Components VisionOS -ExplicitOS Mac | Should -HaveCount 1
+        # }
+
+        It 'does not find VisionOS before supported (Windows)' {
+            Find-UnitySetupInstaller -Version "2022.3.18f1" -Components VisionOS -ExplicitOS Windows `
+            | Should -HaveCount 0
+        }
+
+        It 'finds VisionOS once supported (Windows, explicit)' {
+            Find-UnitySetupInstaller -Version "2022.3.21f1" -Components VisionOS -ExplicitOS Windows `
+            | Should -HaveCount 1
+        }
+
+        It 'finds VisionOS once supported (Windows, implicit)' {
+            Find-UnitySetupInstaller -Version "2022.3.21f1" -ExplicitOS Windows `
+            | Where-Object -Property ComponentType -Eq VisionOS `
+            | Should -HaveCount 1
+        }
+    }
+}

--- a/Tests/UnitTests/Update-UnityPackageManagerConfig.Tests.ps1
+++ b/Tests/UnitTests/Update-UnityPackageManagerConfig.Tests.ps1
@@ -1,21 +1,21 @@
-BeforeAll {
-    Import-Module "$PSScriptRoot\..\..\UnitySetup\UnitySetup.psd1" -Force
-
-    Mock -CommandName 'Import-UnityProjectManifest' -MockWith { @() } -ModuleName UnitySetup
-    Mock -CommandName 'Import-TOMLFile' -MockWith { @() } -ModuleName UnitySetup
-    Mock -CommandName 'Update-PackageAuthConfig' -MockWith { @() } -ModuleName UnitySetup
-    Mock -CommandName 'Export-UPMConfig' -MockWith { @() } -ModuleName UnitySetup
-    Mock -CommandName 'Invoke-WebRequest' -MockWith {
-        return [pscustomobject]@{
-            StatusCode = 200
-            Content    = '{"patToken": {"token": "mockedPATToken"}}'
-        }
-    } -ModuleName UnitySetup
-    Mock -CommandName 'Confirm-PAT' -MockWith { $true } -ModuleName UnitySetup
-}
-
 Describe 'Update-UnityPackageManagerConfig' {
 
+    BeforeEach {
+        Import-Module "$PSScriptRoot\..\..\UnitySetup\UnitySetup.psd1" -Force
+    
+        Mock -CommandName 'Import-UnityProjectManifest' -MockWith { @() } -ModuleName UnitySetup
+        Mock -CommandName 'Import-TOMLFile' -MockWith { @() } -ModuleName UnitySetup
+        Mock -CommandName 'Update-PackageAuthConfig' -MockWith { @() } -ModuleName UnitySetup
+        Mock -CommandName 'Export-UPMConfig' -MockWith { @() } -ModuleName UnitySetup
+        Mock -CommandName 'Invoke-WebRequest' -MockWith {
+            return [pscustomobject]@{
+                StatusCode = 200
+                Content    = '{"patToken": {"token": "mockedPATToken"}}'
+            }
+        } -ModuleName UnitySetup
+        Mock -CommandName 'Confirm-PAT' -MockWith { $true } -ModuleName UnitySetup
+    }
+    
     Context 'Input Validation' {
         It 'throws on empty parameters' {
             { Update-UnityPackageManagerConfig } | Should -Throw "*insufficient number of parameters were provided."

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -37,6 +37,7 @@ enum UnitySetupComponent {
     Lumin = (1 -shl 15)
     Linux_IL2CPP = (1 -shl 16)
     Windows_Server = (1 -shl 17)
+    VisionOS = (1 -shl 18)
     All = (1 -shl 18) - 1
 }
 
@@ -123,6 +124,7 @@ class UnitySetupInstance {
         $componentTests[[UnitySetupComponent]::Facebook] = , [io.path]::Combine("$playbackEnginePath", "Facebook");
         $componentTests[[UnitySetupComponent]::Vuforia]  = , [io.path]::Combine("$playbackEnginePath", "VuforiaSupport");
         $componentTests[[UnitySetupComponent]::WebGL]    = , [io.path]::Combine("$playbackEnginePath", "WebGLSupport");
+        $componentTests[[UnitySetupComponent]::VisionOS] = , [io.path]::Combine("$playbackEnginePath", "VisionOSPlayer");
 
         $componentTests.Keys | ForEach-Object {
             foreach ( $test in $componentTests[$_] ) {
@@ -343,6 +345,8 @@ function ConvertTo-UnitySetupComponent {
         [UnityVersion] $Version
     )
 
+    $currentOS = Get-OperatingSystem
+
     if ($Version) {
         if ($Version.Major -ge 2019) {
             if ($Component -band [UnitySetupComponent]::UWP) {
@@ -356,6 +360,15 @@ function ConvertTo-UnitySetupComponent {
 
                 $Component -= [UnitySetupComponent]::UWP;
             }
+        }
+
+        if ($Component -band [UnitySetupComponent]::VisionOS -and ( `
+            $currentOS -notin [OperatingSystem]::Windows, [OperatingSystem]::Mac `
+            -or $currentOS -eq [OperatingSystem]::Mac -and [UnityVersion]::Compare($Version, [UnityVersion]"2022.3.18f1") -lt 0 `
+            -or $currentOS -eq [OperatingSystem]::Windows -and [UnityVersion]::Compare($Version, [UnityVersion]"2022.3.21f1") -lt 0 `
+        )) {
+            Write-Verbose "VisionOS is only supported starting in Unity version 2022.3.18f1 on Mac or 2022.3.21f1 on Windows - removing $([UnitySetupComponent]::VisionOS)"
+            $Component -= [UnitySetupComponent]::VisionOS;
         }
     }
 
@@ -436,6 +449,7 @@ function Find-UnitySetupInstaller {
         [UnitySetupComponent]::Lumin          = , "$targetSupport/UnitySetup-Lumin-Support-for-Editor-$Version.$installerExtension";
         [UnitySetupComponent]::Linux_IL2CPP   = , "$targetSupport/UnitySetup-Linux-IL2CPP-Support-for-Editor-$Version.$installerExtension";
         [UnitySetupComponent]::Windows_Server = , "$targetSupport/UnitySetup-Windows-Server-Support-for-Editor-$Version.$installerExtension";
+        [UnitySetupComponent]::VisionOS       = , "$targetSupport/UnitySetup-VisionOS-Support-for-Editor-$Version.$installerExtension";
     }
 
     # In 2019.x there is only IL2CPP UWP so change the search for UWP_IL2CPP

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -38,7 +38,7 @@ enum UnitySetupComponent {
     Linux_IL2CPP = (1 -shl 16)
     Windows_Server = (1 -shl 17)
     VisionOS = (1 -shl 18)
-    All = (1 -shl 18) - 1
+    All = (1 -shl 19) - 1
 }
 
 [Flags()]
@@ -401,12 +401,15 @@ function Find-UnitySetupInstaller {
         [UnitySetupComponent] $Components = [UnitySetupComponent]::All,
 
         [parameter(Mandatory = $false)]
-        [string] $Hash = ""
+        [string] $Hash = "",
+
+        [parameter(Mandatory = $false)]
+        [OperatingSystem] $ExplicitOS
     )
 
     $Components = ConvertTo-UnitySetupComponent -Component $Components -Version $Version
 
-    $currentOS = Get-OperatingSystem
+    $currentOS = $ExplicitOS ?? (Get-OperatingSystem)
     switch ($currentOS) {
         ([OperatingSystem]::Windows) {
             $targetSupport = "TargetSupportInstaller"
@@ -533,7 +536,7 @@ function Find-UnitySetupInstaller {
                 Select-Object -ExpandProperty href -ErrorAction SilentlyContinue |
                 Where-Object {
                     $link = $_
-
+                    
                     foreach ( $installer in $installerTemplates.Keys ) {
                         foreach ( $template in $installerTemplates[$installer] ) {
                             if ( $link -like "*$template*" ) { return $true }


### PR DESCRIPTION
VisionOS is a new Editor component available on Mac as of 2022.3.18f1 and Windows as of 2022.3.21f1.