### PR TITLE
Remove PSCore-only feature

### DIFF
--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -409,7 +409,14 @@ function Find-UnitySetupInstaller {
 
     $Components = ConvertTo-UnitySetupComponent -Component $Components -Version $Version
 
-    $currentOS = $ExplicitOS ?? (Get-OperatingSystem)
+    if ($ExplicitOS) {
+        Write-Host ""
+        $currentOS = $ExplicitOS
+    }
+    else {
+        $currentOS = Get-OperatingSystem
+    }
+
     switch ($currentOS) {
         ([OperatingSystem]::Windows) {
             $targetSupport = "TargetSupportInstaller"


### PR DESCRIPTION
Mistakenly added a null-coalescing operator to #267, which is a PowerShell 7+ feature. This PR switches it to a more verbose `if` statement.