### PR TITLE
Version bump to 6.0 for the break to back compatibility in Update-UnityPackageManagerConfig

### DIFF
--- a/UnitySetup/UnitySetup.psd1
+++ b/UnitySetup/UnitySetup.psd1
@@ -14,7 +14,7 @@
     RootModule        = 'UnitySetup'
 
     # Version number of this module.
-    ModuleVersion     = '5.7'
+    ModuleVersion     = '6.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
Per discussion with Josh, we should bump to 6.0 because breaking changes were made in the public Update-UnityPackageManagerConfig.

Specifically:
- ProjectManifestPath must now be a leaf node file, existing scripts passing a folder path should now use SearchPath
- Scripts that were using a SearchDepth without a SearchPath will error (previously this was not validated, would simply go unused if you passed a non-folder target and a depth)