### PR TITLE
Only print Auth token when in Verbose mode

### DIFF
--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -2824,7 +2824,7 @@ function Update-UnityPackageManagerConfig {
         }
 
         Write-Verbose "Summary"
-        Write-Output $upmConfigs
+        Write-Verbose $upmConfigs
     }
 
     if ($VerifyOnly) {


### PR DESCRIPTION
It looks like the intention was to print the Auth token only when in Verbose mode, taking into account previous line.

Printing Auth PAT to console in normal mode may expose PAT to a party with malicious intent.