### PR TITLE
Removed the auth token from the output, replaced with a 'Suceeded' column

### DIFF
--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -2823,13 +2823,19 @@ function Update-UnityPackageManagerConfig {
             Export-UPMConfig -UPMConfig $upmConfigs -tomlFilePaths $tomlFilePaths
         }
 
-        Write-Verbose "Summary"
-        $upmConfigs | ForEach-Object {
-            [PSCustomObject]@{
-                ScopedURL = $_.ScopedURL
-                Succeeded = -not [string]::IsNullOrEmpty($_.Auth)
-            }
-        } | Format-Table -AutoSize
+        if ($upmConfigs) {
+            Write-Verbose "Summary"
+            $upmConfigs = $upmConfigs | ForEach-Object {
+                [PSCustomObject]@{
+                    ScopedURL = $_.ScopedURL
+                    Succeeded = -not [string]::IsNullOrEmpty($_.Auth)
+                }
+            } | Format-Table -AutoSize
+        
+            Write-Verbose $upmConfigs
+        } else {
+            Write-Verbose "No changes were made"
+        }
     }
 
     if ($VerifyOnly) {

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -2830,7 +2830,7 @@ function Update-UnityPackageManagerConfig {
                     ScopedURL = $_.ScopedURL
                     Succeeded = -not [string]::IsNullOrEmpty($_.Auth)
                 }
-            } | Format-Table -AutoSize | Out-String
+            } | Format-Table -AutoSize
         
             Write-Verbose $upmConfigs
         } else {

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -2830,7 +2830,7 @@ function Update-UnityPackageManagerConfig {
                     ScopedURL = $_.ScopedURL
                     Succeeded = -not [string]::IsNullOrEmpty($_.Auth)
                 }
-            } | Format-Table -AutoSize
+            } | Format-Table -AutoSize | Out-String
         
             Write-Verbose $upmConfigs
         } else {

--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -2824,7 +2824,12 @@ function Update-UnityPackageManagerConfig {
         }
 
         Write-Verbose "Summary"
-        Write-Output $upmConfigs
+        $upmConfigs | ForEach-Object {
+            [PSCustomObject]@{
+                ScopedURL = $_.ScopedURL
+                Succeeded = -not [string]::IsNullOrEmpty($_.Auth)
+            }
+        } | Format-Table -AutoSize
     }
 
     if ($VerifyOnly) {


### PR DESCRIPTION
A couple things going on here:
- We were printing the output via write-output and thereby printing auth tokens in the console even when not running verbose
- Switching to printing a success var instead of an auth token

Here is what it looks like now:
![image](https://github.com/user-attachments/assets/452e991f-5347-49c3-9819-9859b2e010f1)
