### PR TITLE
Add out-string back in to fix data type error

### DIFF
--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -2830,7 +2830,7 @@ function Update-UnityPackageManagerConfig {
                     ScopedURL = $_.ScopedURL
                     Succeeded = -not [string]::IsNullOrEmpty($_.Auth)
                 }
-            } | Format-Table -AutoSize
+            } | Format-Table -AutoSize | Out-String
         
             Write-Verbose $upmConfigs
         } else {


### PR DESCRIPTION
I made a mistake iterating on the PR for the output table update - without the out-string the Write-Verbose at the end of the conditional throws an error on the datatable input.