### PR TITLE
Fix for unity package manager authentication caching and build dependency.

### DIFF
--- a/UnitySetup/UnitySetup.psm1
+++ b/UnitySetup/UnitySetup.psm1
@@ -2349,7 +2349,7 @@ function Read-PATFromUser($OrgName) {
 }
 
 function Get-RegExForConfig($Org, $Project, $Feed, $PAT) {
-    $regexresult = "[`r`n]*\[npmAuth\.""https:\/\/pkgs.dev.azure.com\/$($Org)\/"
+    $regexresult = "[\n\r\s]*\[npmAuth\.""https:\/\/pkgs.dev.azure.com\/$($Org)\/"
     if (-not [string]::IsNullOrEmpty($Project)) {
         $regexresult += "$($Project)\/"
     }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ install:
 
     Install-Module 'powershell-yaml' -Scope CurrentUser -Force -AllowClobber -Verbose
 
-    Install-Module 'Az.Accounts' -RequiredVersion 2.15.1 -Scope CurrentUser -Force -AllowClobber -Verbose
+    Install-Module 'Az.Accounts' -RequiredVersion 2.19.0 -Scope CurrentUser -Force -AllowClobber -Verbose
 build_script:
 - ps: .\build.ps1 -Revision "$env:APPVEYOR_BUILD_NUMBER" -Suffix "$env:APPVEYOR_REPO_BRANCH"
 deploy_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,6 @@ install:
 - ps: >-
     $ErrorActionPreference = 'Stop'
 
-    Install-PackageProvider -Name NuGet -Force
-
     Remove-Module 'PowerShellGet' -Force -ErrorAction SilentlyContinue -Verbose
 
     Install-Module 'PowerShellGet' -Scope CurrentUser -Force -AllowClobber -Verbose


### PR DESCRIPTION
Old entry would not be removed because it would not be found by bad regex - now working in my testing.
Had to remove nuget package provider install - doesn't seem to exist anymore in appveyor or my local dev box and seems to work without it (we'll see if publish works when this gets merged).